### PR TITLE
リリース / 1.5.3

### DIFF
--- a/ImageChecker_3/Models/TitleBarText.cs
+++ b/ImageChecker_3/Models/TitleBarText.cs
@@ -42,8 +42,8 @@ namespace ImageChecker_3.Models
         {
             const int major = 1;
             const int minor = 5;
-            const int patch = 2;
-            const string date = "20250423";
+            const int patch = 3;
+            const string date = "20250426";
             const string suffixId = "a";
 
             Version = $"{major}.{minor}.{patch} ({date}{suffixId})";

--- a/ImageChecker_3/Tags/TagGenerator.cs
+++ b/ImageChecker_3/Tags/TagGenerator.cs
@@ -157,12 +157,19 @@ namespace ImageChecker_3.Tags
         {
             var relPosition = previewContainer.RelativePosition;
             var ws = previewContainer.GetImageFileNames();
+
+            var scl = previewContainer.Scale.ToString("0.00", CultureInfo.InvariantCulture);
+            if (Regex.IsMatch(scl, @"\.\d0"))
+            {
+                scl = Regex.Replace(scl, "0$", string.Empty);
+            }
+
             var tag = baseText
                 .Replace("$a", ws[0])
                 .Replace("$b", ws[1])
                 .Replace("$c", ws[2])
                 .Replace("$d", ws[3])
-                .Replace("$scale", previewContainer.Scale.ToString("0.0", CultureInfo.InvariantCulture))
+                .Replace("$scale", scl)
                 .Replace("$x", ((int)relPosition.X).ToString(CultureInfo.CurrentCulture))
                 .Replace("$y", ((int)relPosition.Y).ToString(CultureInfo.CurrentCulture))
                 .Replace("$targetLayerIndex", GetLayerIndex(ws).ToString());

--- a/ImageChecker_3Test/Models/TagGeneratorTest.cs
+++ b/ImageChecker_3Test/Models/TagGeneratorTest.cs
@@ -45,6 +45,23 @@ namespace ImageChecker_3Test.Models
             Assert.That(actual, Is.EqualTo(expect));
         }
 
+        [TestCase(1.0, "1.0")]
+        [TestCase(1.05, "1.05")]
+        [TestCase(1.1, "1.1")]
+        public void GetTagTest_precise_scaleValue(double scale, string expected)
+        {
+            var pc = new PreviewContainer
+            {
+                Scale = scale,
+            };
+
+            var tagText = @"<image a=""$a"" b=""$b"" c=""$c"" d=""$d"" x=""$x"" y=""$y"" scale=""$scale"" />";
+            var actual = TagGenerator.GetTag(tagText, pc, false);
+            var expect = $@"<image a="""" b="""" c="""" d="""" x=""0"" y=""360"" scale=""{expected}"" />";
+
+            Assert.That(actual, Is.EqualTo(expect));
+        }
+
         [Test]
         public void GetTagTest_EmptyValues()
         {


### PR DESCRIPTION
 - 修正
     - Scale をクリップボードに転送される際、意図せず値が丸められる不具合を修正。