### PR TITLE
リリース / v1.6.1

### DIFF
--- a/ImageChecker_3/Images/ImageWrapperProvider.cs
+++ b/ImageChecker_3/Images/ImageWrapperProvider.cs
@@ -32,7 +32,7 @@ namespace ImageChecker_3.Images
 
         public int GetBaseWidth()
         {
-            var baseSizeImage = imageWrappers.FirstOrDefault(w => w.ImageFileInfo.Width >= 1280 && w.ImageFileInfo.Width <= 1520);
+            var baseSizeImage = imageWrappers.FirstOrDefault(w => w.ImageFileInfo.Width is >= 960 and <= 1920);
             return baseSizeImage == null ? 0 : (int)baseSizeImage.ImageFileInfo.Width;
         }
     }

--- a/ImageChecker_3/Models/TitleBarText.cs
+++ b/ImageChecker_3/Models/TitleBarText.cs
@@ -42,8 +42,8 @@ namespace ImageChecker_3.Models
         {
             const int major = 1;
             const int minor = 6;
-            const int patch = 0;
-            const string date = "20250426";
+            const int patch = 1;
+            const string date = "20250429";
             const string suffixId = "a";
 
             Version = $"{major}.{minor}.{patch} ({date}{suffixId})";


### PR DESCRIPTION
- 修正
    - 大きめの画像・小さめの画像を読み込んだ際、プレビューのサイズが自動設定されない不具合に対処。 
        - ソースとなる値の検出範囲を広げることによって、対処した。